### PR TITLE
Add httpRuntime setting for max request length

### DIFF
--- a/StorageManager/Web.config
+++ b/StorageManager/Web.config
@@ -15,6 +15,11 @@
 	<appSettings/>
 	<connectionStrings/>
 	<system.web>
+		<!--
+			Increase the maximum request size for normal request.
+			This value is in kilobytes!
+		-->
+		<httpRuntime maxRequestLength="1048576" />
 		<!-- 
             Set compilation debug="true" to insert debugging 
             symbols into the compiled page. Because this 


### PR DESCRIPTION
The security limit does not actually increase the allowed size from the default.

http://stackoverflow.com/a/3853785/706724

Very cool project otherwise!