### PR TITLE
Fix Azurite connection failure due to SDK/API version mismatch

### DIFF
--- a/src/StorageLibrary/Azure/AzureContainer.cs
+++ b/src/StorageLibrary/Azure/AzureContainer.cs
@@ -16,12 +16,16 @@ namespace StorageLibrary.Azure
 		public AzureContainer(StorageFactoryConfig config)
 		: base(config) { }
 
+		BlobClientOptions ClientOptions => IsAzurite
+			? new BlobClientOptions(BlobClientOptions.ServiceVersion.V2024_11_04)
+			: new BlobClientOptions();
+
+		BlobServiceClient ServiceClient => new BlobServiceClient(ConnectionString, ClientOptions);
+
 		public async Task<List<CloudBlobContainerWrapper>> ListContainersAsync()
 		{
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-
 			List<CloudBlobContainerWrapper> results = new List<CloudBlobContainerWrapper>();
-			await foreach (var container in blobServiceClient.GetBlobContainersAsync())
+			await foreach (var container in ServiceClient.GetBlobContainersAsync())
 			{
 				results.Add(new CloudBlobContainerWrapper
 				{
@@ -34,8 +38,7 @@ namespace StorageLibrary.Azure
 
 		public async Task<List<BlobItemWrapper>> ListBlobsAsync(string containerName, string path)
 		{
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-			BlobContainerClient container = blobServiceClient.GetBlobContainerClient(containerName);
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
 
 			List<BlobItemWrapper> results = new List<BlobItemWrapper>();
 			await foreach (BlobHierarchyItem blobItem in container.GetBlobsByHierarchyAsync(BlobTraits.None, BlobStates.None, "/", path, CancellationToken.None))
@@ -61,50 +64,36 @@ namespace StorageLibrary.Azure
 
 		public async Task DeleteAsync(string containerName)
 		{
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-			BlobContainerClient container = blobServiceClient.GetBlobContainerClient(containerName);
-
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
 			await container.DeleteAsync();
 		}
 
 		public async Task CreateAsync(string containerName, bool publicAccess)
 		{
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-			BlobContainerClient container = blobServiceClient.GetBlobContainerClient(containerName);
-
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
 			PublicAccessType accessType = publicAccess ? PublicAccessType.BlobContainer : PublicAccessType.None;
 			await container.CreateAsync(accessType);
 		}
 
 		public async Task DeleteBlobAsync(string containerName, string blobName)
 		{
-
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-			BlobContainerClient container = blobServiceClient.GetBlobContainerClient(containerName);
-
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
 			BlobClient blob = container.GetBlobClient(blobName);
-
 			await blob.DeleteAsync();
 		}
 
 		public async Task CreateBlobAsync(string containerName, string blobName, Stream fileContent)
 		{
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-			BlobContainerClient container = blobServiceClient.GetBlobContainerClient(containerName);
-
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
 			await container.UploadBlobAsync(blobName, fileContent);
 		}
 
 		public async Task<string> GetBlobAsync(string containerName, string blobName)
 		{
-			BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
-			BlobContainerClient container = blobServiceClient.GetBlobContainerClient(containerName);
-
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
 			BlobClient blob = container.GetBlobClient(blobName);
-
 			string tmpPath = Util.File.GetTempFileName();
 			await blob.DownloadToAsync(tmpPath);
-
 			return tmpPath;
 		}
 	}

--- a/src/StorageLibrary/Azure/AzureFile.cs
+++ b/src/StorageLibrary/Azure/AzureFile.cs
@@ -17,14 +17,19 @@ namespace StorageLibrary.Azure
 		public AzureFile(StorageFactoryConfig config)
 		: base(config) { }
 
+		ShareClientOptions ClientOptions => IsAzurite
+			? new ShareClientOptions(ShareClientOptions.ServiceVersion.V2024_11_04)
+			: new ShareClientOptions();
+
+		ShareServiceClient ServiceClient => new ShareServiceClient(ConnectionString, ClientOptions);
+
 		public async Task<List<FileShareWrapper>> ListFileSharesAsync()
 		{
 			System.Threading.CancellationToken cancellationToken = new System.Threading.CancellationToken();
-			ShareServiceClient client = new ShareServiceClient(ConnectionString);
 
 			List<FileShareWrapper> items = new List<FileShareWrapper>();
 
-			var shares = client.GetSharesAsync(ShareTraits.None, ShareStates.None, null, cancellationToken);
+			var shares = ServiceClient.GetSharesAsync(ShareTraits.None, ShareStates.None, null, cancellationToken);
 			await foreach (var share in shares)
 				items.Add(new FileShareWrapper { Name = share.Name });
 
@@ -33,8 +38,6 @@ namespace StorageLibrary.Azure
 
 		public async Task<List<FileShareItemWrapper>> ListFilesAndDirsAsync(string share, string folder = null)
 		{
-			ShareClient client = new ShareClient(ConnectionString, share);
-
 			ShareDirectoryClient dir = GetShareDirectoryClient(share, folder);
 
 			List<FileShareItemWrapper> items = new List<FileShareItemWrapper>();
@@ -111,19 +114,17 @@ namespace StorageLibrary.Azure
 
 			}
 
-			ShareServiceClient client = new ShareServiceClient(ConnectionString);
-			await client.CreateShareAsync(share, options);
+			await ServiceClient.CreateShareAsync(share, options);
 		}
 
 		public async Task DeleteFileShareAsync(string share)
 		{
-			ShareServiceClient client = new ShareServiceClient(ConnectionString);
-			await client.DeleteShareAsync(share);
+			await ServiceClient.DeleteShareAsync(share);
 		}
 
 		private ShareDirectoryClient GetShareDirectoryClient(string share, string folder)
 		{
-			ShareClient client = new ShareClient(ConnectionString, share);
+			ShareClient client = new ShareClient(ConnectionString, share, ClientOptions);
 			return string.IsNullOrWhiteSpace(folder) ? client.GetRootDirectoryClient() : client.GetDirectoryClient(folder);
 		}
 

--- a/src/StorageLibrary/Azure/AzureQueue.cs
+++ b/src/StorageLibrary/Azure/AzureQueue.cs
@@ -14,11 +14,17 @@ namespace StorageLibrary.Azure
 		public AzureQueue(StorageFactoryConfig config)
 		: base(config) { }
 
+		QueueClientOptions ClientOptions => IsAzurite
+			? new QueueClientOptions(QueueClientOptions.ServiceVersion.V2024_11_04)
+			: new QueueClientOptions();
+
+		QueueServiceClient ServiceClient => new QueueServiceClient(ConnectionString, ClientOptions);
+		QueueClient GetQueueClient(string queueName) => new QueueClient(ConnectionString, queueName, ClientOptions);
+
 		public async Task<List<QueueWrapper>> ListQueuesAsync()
 		{
-			QueueServiceClient client = new QueueServiceClient(ConnectionString);
 			List<QueueWrapper> results = new List<QueueWrapper>();
-			await foreach (var q in client.GetQueuesAsync())
+			await foreach (var q in ServiceClient.GetQueuesAsync())
 				results.Add(new QueueWrapper { Name = q.Name });
 
 			return results;
@@ -26,7 +32,7 @@ namespace StorageLibrary.Azure
 
 		public async Task<List<PeekedMessageWrapper>> GetAllMessagesAsync(string queueName)
 		{
-			QueueClient queueClient = new QueueClient(ConnectionString, queueName);
+			QueueClient queueClient = GetQueueClient(queueName);
 			PeekedMessage[] msgs = await queueClient.PeekMessagesAsync(queueClient.MaxPeekableMessages);
 
 			List<PeekedMessageWrapper> results = new List<PeekedMessageWrapper>();
@@ -39,28 +45,24 @@ namespace StorageLibrary.Azure
 
 		public async Task DequeueMessage(string queueName)
 		{
-			QueueClient queueClient = new QueueClient(ConnectionString, queueName);
-
+			QueueClient queueClient = GetQueueClient(queueName);
 			QueueMessage msg = await queueClient.ReceiveMessageAsync();
 			await queueClient.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
 		}
 
 		public async Task CreateAsync(string queueName)
 		{
-			QueueServiceClient client = new QueueServiceClient(ConnectionString);
-			await client.CreateQueueAsync(queueName);
+			await ServiceClient.CreateQueueAsync(queueName);
 		}
 
 		public async Task DeleteAsync(string queueName)
 		{
-			QueueClient queueClient = new QueueClient(ConnectionString, queueName);
-			await queueClient.DeleteAsync();
+			await GetQueueClient(queueName).DeleteAsync();
 		}
 
 		public async Task CreateMessageAsync(string queueName, string message)
 		{
-			QueueClient queueClient = new QueueClient(ConnectionString, queueName);
-			await queueClient.SendMessageAsync(message);
+			await GetQueueClient(queueName).SendMessageAsync(message);
 		}
 	}
 }

--- a/src/StorageLibrary/StorageObject.cs
+++ b/src/StorageLibrary/StorageObject.cs
@@ -1,4 +1,5 @@
 
+using System;
 using Azure;
 
 namespace StorageLibrary
@@ -19,10 +20,10 @@ namespace StorageLibrary
 			if (config.Provider != CloudProvider.Azure)
 				return;
 
-			IsAzurite = config.IsAzurite;
 			if (!string.IsNullOrEmpty(config.AzureConnectionString))
 			{
 				ConnectionString = config.AzureConnectionString;
+				IsAzurite = config.IsAzurite || IsAzuriteConnectionString(config.AzureConnectionString);
 			}
 			else if (config.AzureKey.Contains("SharedAccessSignature="))
 			{
@@ -30,6 +31,7 @@ namespace StorageLibrary
 			}
 			else
 			{
+				IsAzurite = config.IsAzurite;
 				Account = config.AzureAccount;
 				Key = config.AzureKey;
 				if (!string.IsNullOrEmpty(config.AzureEndpoint))
@@ -38,5 +40,9 @@ namespace StorageLibrary
 				ConnectionString = string.Format(CONNSTRING_TEMPLATE, Account, Key, Endpoint);
 			}
 		}
+
+		static bool IsAzuriteConnectionString(string connectionString) =>
+			connectionString.Contains("devstoreaccount1", StringComparison.OrdinalIgnoreCase) ||
+			connectionString.Contains("UseDevelopmentStorage=true", StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/src/web/Directory.Build.props
+++ b/src/web/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <AzureStorageWebExplorerVersion>3.1.1</AzureStorageWebExplorerVersion>
+    <AzureStorageWebExplorerVersion>3.2.0</AzureStorageWebExplorerVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- `Azure.Storage.Blobs/Queues/Files 12.x` defaults to a REST API version newer than what Azurite supports, causing a `400 Bad Request` on every call (reported in #239)
- Pin service version to `V2024_11_04` for Blob, Queue, and File clients when Azurite is detected
- Auto-detect Azurite from the connection string (`devstoreaccount1` or `UseDevelopmentStorage=true`), so Aspire setups work without needing `AZURITE=true`

## Test plan

- [x] Run `just compose` and verify the app loads against Azurite at http://localhost:8080
- [x] Verify blobs, queues, tables, and file shares all work
- [x] Verify normal Azure Storage connections are unaffected (no version pinning applied)

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)