### PR TITLE
Fix S3 object URLs to use configured region (fixes #261)

### DIFF
--- a/src/StorageLibrary/AWS/AWSBucket.cs
+++ b/src/StorageLibrary/AWS/AWSBucket.cs
@@ -17,8 +17,10 @@ namespace StorageLibrary.AWS
 	internal class AWSBucket : StorageObject, IContainer, IDisposable
 	{
 		protected AmazonS3Client _s3Client;
+		private readonly string _region;
 		public AWSBucket(StorageFactoryConfig config): base(config)
 		{
+			_region = config.AwsRegion;
 			var credentials = new BasicAWSCredentials(config.AwsKey, config.AwsSecret);
 			_s3Client = new AmazonS3Client(credentials, RegionEndpoint.GetBySystemName(config.AwsRegion));
 		}
@@ -133,7 +135,7 @@ namespace StorageLibrary.AWS
 			var blobs = new List<BlobItemWrapper>();
 			var response = await _s3Client.ListObjectsV2Async(request);
 
-			var uriTemplate = $"https://{bucket}.s3.{RegionEndpoint.USEast1.SystemName}.amazonaws.com/";
+			var uriTemplate = $"https://{bucket}.s3.{_region}.amazonaws.com/";
 
 			foreach (S3Object entry in response.S3Objects ?? [])
 			{

--- a/src/web/Directory.Build.props
+++ b/src/web/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <AzureStorageWebExplorerVersion>3.2.1</AzureStorageWebExplorerVersion>
+    <AzureStorageWebExplorerVersion>3.2.2</AzureStorageWebExplorerVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## What
`AWSBucket.ListBlobsAsync` composed virtual-hosted S3 object URLs with a **hardcoded** `RegionEndpoint.USEast1`, so the returned links were wrong for any bucket outside `us-east-1`.

## Change
- Capture the configured region into a `_region` field in the constructor (the `AmazonS3Client` was already built with `config.AwsRegion`, but `config` isn't in scope inside `ListBlobsAsync`, and the base `StorageObject` doesn't retain it).
- Use `_region` in the URL template instead of the hardcoded constant.

```diff
-        var uriTemplate = $"https://{bucket}.s3.{RegionEndpoint.USEast1.SystemName}.amazonaws.com/";
+        var uriTemplate = $"https://{bucket}.s3.{_region}.amazonaws.com/";
```

## Impact
- Listing/reading already worked (client uses the right region); this only corrects the **display/link URLs** returned in `BlobItemWrapper`.
- `us-east-1` buckets are unaffected.

## Testing
- CI (`dotnet build` + `dotnet test ./tests/StorageLibTests`) runs on this PR.

Closes #261