### PR TITLE
Direct browser-to-storage uploads and stop parsing item URLs (4.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ azurestorageexplorer.sln
 credentials.json
 .env
 .vscode/
-
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,12 +46,100 @@ Azure Storage Explorer is a web-based application for managing Azure Storage res
 ```
 azurestorageexplorer/
 ├── justfile                 # Build automation commands
-├── docker-compose.yml       # Docker Compose manifest for Azurite + Explorer
+├── docker-compose/
+│   └── azurestorageexplorer.yaml   # Azurite + Explorer manifest
+├── helm/                    # Helm chart
 ├── k8s/                     # Kubernetes manifests
 │   ├── deployment.yaml
 │   └── service.yaml
-└── src/                     # .NET 10.0 Blazor Server application
+├── src/
+│   ├── Dockerfile
+│   ├── StorageLibrary/      # Cloud-agnostic storage abstraction library
+│   └── web/                 # .NET 10.0 Blazor Web App
+└── tests/
+    └── StorageLibTests/     # MSTest unit tests for StorageLibrary
 ```
+
+## Architecture
+
+The solution has two projects and one test project:
+
+- **`src/StorageLibrary/`** — cloud-agnostic storage abstraction library
+- **`src/web/`** — Blazor Server app that references StorageLibrary
+- **`tests/StorageLibTests/`** — MSTest unit tests for StorageLibrary (uses `azure.data` file for credentials, not environment variables)
+
+### StorageLibrary
+
+The core abstraction is `StorageFactory`, which creates provider-specific implementations based on `StorageFactoryConfig`. Four interfaces define the contract:
+
+| Interface | Azure impl | AWS impl | GCP impl |
+|-----------|-----------|----------|----------|
+| `IContainer` | `AzureContainer` | `AWSBucket` | `GCPBucket` |
+| `IQueue` | `AzureQueue` | — | — |
+| `ITable` | `AzureTable` | — | — |
+| `IFile` | `AzureFile` | — | — |
+
+Mock implementations live in `Mocks/` and are used when `MOCK=true` env var is set or when `StorageFactory()` is called with no arguments. `Common/` contains provider-neutral wrapper types (`BlobItemWrapper`, `QueueWrapper`, `TableEntityWrapper`, etc.) used as return values across the interface layer.
+
+**Never derive an item's identity from its URL.** `BlobItemWrapper` and `FileShareItemWrapper`
+take the container/share and the item's name as constructor arguments, because the caller
+always has both; `Url` is carried for display and equality only and is never parsed.
+`Common/StorageItemName.Split` turns the name into `Path` + `Name`, and `Path + Name ==
+FullName` always holds. URLs cannot be parsed reliably here: the account name sits in the host
+on Azure but in the *path* on Azurite and custom endpoints, and names arrive percent-encoded.
+Getting this wrong is what made listing blobs throw
+`length ('-3') must be a non-negative value`.
+
+Nullable reference types are enabled in `src/web` only, **not** in `StorageLibrary` — a `?` annotation there emits CS8632.
+
+### Blazor Web App
+
+`BaseComponent` is the base class for all storage pages. On init it loads `Credentials` from `ProtectedSessionStorage`, redirects to `/login` if missing, and builds a `StorageFactory` via `Util.GetStorageFactory()`.
+
+`Login.razor.cs` checks environment variables on init and auto-authenticates if they are present, bypassing the login form.
+
+Credentials are stored in browser session storage (encrypted by ASP.NET's Data Protection) under `wasm_*` keys.
+
+A `BASEPATH` environment variable can set a path prefix for reverse proxy deployments.
+
+Prometheus metrics are exposed via `prometheus-net.AspNetCore` and counters are incremented via `BaseComponent.Increment()`.
+
+### Blob uploads
+
+Blob uploads try to go **browser → storage** first, so the bytes never cross the Blazor
+circuit. `IContainer.GetBlobUploadUrlAsync` mints a 15-minute SAS scoped to the single
+blob with `Create | Write`, and `uploadBlobToSasUrl` (in `App.razor`) `PUT`s the file
+directly. There is no setting to turn this on — it is attempted whenever possible.
+
+It falls back to uploading through the server (`CreateBlobAsync`, capped at
+`Util.MAX_UPLOAD_SIZE` — 10 MB unless `MAX_SERVER_UPLOAD_MEGS` says otherwise) whenever
+the direct attempt cannot be made or never reaches storage:
+
+- The credentials cannot sign. Only account+key or a connection string containing
+  `AccountKey=` can; signing in *with* a SAS cannot mint another one.
+- The provider is AWS, GCP, or the mocks — presigned URLs are not wired up there yet.
+- The `PUT` fails at the network level, most often **no CORS rule** on the account.
+
+Direct upload therefore needs a CORS rule on the storage account, for the explorer's own
+origin, allowing `PUT` plus the `x-ms-blob-type`, `content-type`, and `if-none-match`
+headers:
+
+```bash
+az storage cors add --services b --methods PUT OPTIONS \
+  --origins http://localhost:8080 \
+  --allowed-headers x-ms-blob-type content-type if-none-match \
+  --max-age 3600 --account-name <account> --account-key <key>
+```
+
+Two things worth knowing:
+
+- Under `just compose` the URL is signed against the compose hostname `azurite`, which
+  the browser cannot resolve, so uploads always fall back. That is expected.
+- A SAS in a URL is a credential. Anything derived from an exception message must go
+  through `Util.RedactSignatures()` before it is displayed or logged.
+
+File shares (`Files.razor`) upload through the server only — Azure Files needs
+`ShareSasBuilder` and a different protocol (Create File + Put Range).
 
 ## Authentication & Configuration
 
@@ -82,7 +170,12 @@ The application supports multiple authentication methods:
 - `CLOUD_PROVIDER=GCP`
 - `GCP_CREDENTIALS_FILE` - Full path to service account credentials file
 
-**Note:** If `AZURE_STORAGE_CONNECTIONSTRING` is set, other Azure variables are ignored. Otherwise, all three (account, key, endpoint) must be present.
+**Hosting & development:**
+- `MOCK` - Set to `true` to use the in-memory mock implementations
+- `BASEPATH` - URL path prefix for reverse proxy deployments (e.g. `/explorer`)
+- `MAX_SERVER_UPLOAD_MEGS` - Size cap in MB for uploads routed **through the server** (default `10`). Direct browser-to-storage uploads ignore it. Read once at startup; a non-positive or unparseable value falls back to the default.
+
+**Note:** If `AZURE_STORAGE_CONNECTIONSTRING` is set, other Azure variables are ignored. Otherwise, all three (account, key, endpoint) must be present. `AZURE_STORAGE_ENDPOINT` defaults to `core.windows.net`.
 
 ## Building and Running
 
@@ -93,13 +186,17 @@ The application supports multiple authentication methods:
 ### Local Development
 
 ```bash
-# Build the project
-just build
+just build        # build src/web/web.csproj
+just publish      # release build to ./bin, then runs via Kestrel on http://localhost:5000
+just test         # run tests/StorageLibTests/StorageLibTests.csproj
+just dbuild       # build Docker image as azurestorageexplorer:local (stamps BUILD with a timestamp)
+just drun         # run local Docker image at http://localhost:8080
+just compose      # docker-compose with Azurite + explorer (pre-authenticated)
+```
 
-# Publish to bin folder
-just publish
-
-# Application will start with Kestrel, typically on http://localhost:5000
+Run a specific test class:
+```bash
+dotnet test ./tests/StorageLibTests/StorageLibTests.csproj --filter "ClassName=StorageLibTests.ContainersTests"
 ```
 
 ### Docker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,69 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Read [AGENTS.md](AGENTS.md).
 
-## Build & Run Commands
-
-Requires [.NET 10.0 SDK](https://dotnet.microsoft.com/en-us/download) and optionally [just](https://github.com/casey/just).
-
-```bash
-just build        # build src/web/web.csproj
-just publish      # release build to ./bin, then runs via Kestrel on http://localhost:5000
-just test         # run tests/StorageLibTests/StorageLibTests.csproj
-just dbuild       # build Docker image as azurestorageexplorer:local
-just drun         # run local Docker image at http://localhost:8080
-just compose      # docker-compose with Azurite + explorer (pre-authenticated)
-```
-
-Run a specific test class:
-```bash
-dotnet test ./tests/StorageLibTests/StorageLibTests.csproj --filter "ClassName=StorageLibTests.ContainersTests"
-```
-
-## Architecture
-
-The solution has two projects and one test project:
-
-- **`src/StorageLibrary/`** — cloud-agnostic storage abstraction library
-- **`src/web/`** — Blazor Server app that references StorageLibrary
-- **`tests/StorageLibTests/`** — MSTest unit tests for StorageLibrary (uses `azure.data` file for credentials, not environment variables)
-
-### StorageLibrary
-
-The core abstraction is `StorageFactory`, which creates provider-specific implementations based on `StorageFactoryConfig`. Four interfaces define the contract:
-
-| Interface | Azure impl | AWS impl | GCP impl |
-|-----------|-----------|----------|----------|
-| `IContainer` | `AzureContainer` | `AWSBucket` | `GCPBucket` |
-| `IQueue` | `AzureQueue` | — | — |
-| `ITable` | `AzureTable` | — | — |
-| `IFile` | `AzureFile` | — | — |
-
-Mock implementations live in `Mocks/` and are used when `MOCK=true` env var is set or when `StorageFactory()` is called with no arguments. `Common/` contains provider-neutral wrapper types (`BlobItemWrapper`, `QueueWrapper`, `TableEntityWrapper`, etc.) used as return values across the interface layer.
-
-### Blazor Web App
-
-`BaseComponent` is the base class for all storage pages. On init it loads `Credentials` from `ProtectedSessionStorage`, redirects to `/login` if missing, and builds a `StorageFactory` via `Util.GetStorageFactory()`.
-
-`Login.razor.cs` checks environment variables on init and auto-authenticates if they are present, bypassing the login form.
-
-Credentials are stored in browser session storage (encrypted by ASP.NET's Data Protection) under `wasm_*` keys.
-
-A `BASEPATH` environment variable can set a path prefix for reverse proxy deployments.
-
-Prometheus metrics are exposed via `prometheus-net.AspNetCore` and counters are incremented via `BaseComponent.Increment()`.
-
-## Environment Variables
-
-| Variable | Purpose |
-|----------|---------|
-| `AZURE_STORAGE_CONNECTIONSTRING` | Azure connection string (takes precedence over account/key/endpoint) |
-| `AZURE_STORAGE_ACCOUNT` | Azure account name |
-| `AZURE_STORAGE_KEY` | Azure access key |
-| `AZURE_STORAGE_ENDPOINT` | Custom endpoint (default: `core.windows.net`) |
-| `AZURITE` | Set to `true` when connecting to Azurite emulator |
-| `CLOUD_PROVIDER` | `AWS` or `GCP` to switch providers |
-| `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` / `AWS_REGION` | AWS credentials |
-| `GCP_CREDENTIALS_FILE` | Path to GCP service account JSON file |
-| `MOCK` | Set to `true` to use in-memory mock implementations |
-| `BASEPATH` | URL path prefix for reverse proxy (e.g. `/explorer`) |
+All guidance for working with code in this repository lives there — build and run
+commands, architecture, environment variables, and conventions. This file is only a
+pointer, so keep AGENTS.md as the single place to update.

--- a/docker-compose/azurestorageexplorer.yaml
+++ b/docker-compose/azurestorageexplorer.yaml
@@ -8,9 +8,12 @@ services:
       - "10002:10002"
 
   azurestorageexplorer:
+    build:
+      context: ../src
+      dockerfile: Dockerfile
     image: azurestorageexplorer:local
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       - AZURE_STORAGE_CONNECTIONSTRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
       - AZURITE=true

--- a/justfile
+++ b/justfile
@@ -25,16 +25,28 @@ test:
 
 # Build Docker image as azurestorageexplorer:local
 dbuild:
-  docker build --tag azurestorageexplorer:local ./src
+  #!/bin/bash
+  BUILD=$(date +%Y%m%d%H%M%S)
+  echo Building azurestorageexplorer:local with BUILD=$BUILD
+  docker build --build-arg BUILD=$BUILD --tag azurestorageexplorer:local ./src
 
 # Launches the local docker image (azurestorageexplorer:local) at http://localhost:8080
 drun:
   echo App will run on http://localhost:8080
-  docker run --rm -p 8080:8080 --name azurestorageexplorer azurestorageexplorer:local
+  docker run --rm -p 127.0.0.1:8080:8080 --name azurestorageexplorer azurestorageexplorer:local
 
-# Launches a docker compose with azurestorageexplorer:local and azurite
+dbuildrun:
+	just dbuild && just drun
+
+# Extra dotnet test args go after a --, e.g. just dtest -- --filter ClassName~ContainersTests
+# Runs the unit tests in a container, so no local dotnet SDK is needed
+dtest *ARGS:
+  docker build -f ./src/TestDockerfile --tag azurestorageexplorer-tests:local .
+  docker run --rm azurestorageexplorer-tests:local {{ARGS}}
+
+# Builds and launches a docker compose with azurestorageexplorer:local and azurite
 compose:
-  docker-compose -f ./docker-compose/azurestorageexplorer.yaml up 
+  docker-compose -f ./docker-compose/azurestorageexplorer.yaml up --build 
 
 # Stops de docker compose
 uncompose:

--- a/src/StorageLibrary/AWS/AWSBucket.cs
+++ b/src/StorageLibrary/AWS/AWSBucket.cs
@@ -142,11 +142,11 @@ namespace StorageLibrary.AWS
 				if (entry.Key == path)
 					continue;
 
-				blobs.Add(new BlobItemWrapper($"{uriTemplate}{entry.Key}", entry.Size ?? 0, CloudProvider.AWS));
+				blobs.Add(new BlobItemWrapper($"{uriTemplate}{entry.Key}", bucket, entry.Key, true, entry.Size ?? 0, CloudProvider.AWS));
 			}
 
 			foreach (string commonPrefix in response.CommonPrefixes ?? [])
-				blobs.Add(new BlobItemWrapper($"{uriTemplate}{commonPrefix}", 0, CloudProvider.AWS));
+				blobs.Add(new BlobItemWrapper($"{uriTemplate}{commonPrefix}", bucket, commonPrefix, false, 0, CloudProvider.AWS));
 
 			return blobs;
 		}
@@ -167,6 +167,13 @@ namespace StorageLibrary.AWS
 			return buckets;
 		}
 	
+		// Presigned PUT URLs (GetPreSignedURL) are not wired up yet; callers fall back
+		// to uploading through the server.
+		public Task<string> GetBlobUploadUrlAsync(string bucket, string key, TimeSpan validFor)
+		{
+			return Task.FromResult<string>(null);
+		}
+
 		public void Dispose()
     	{
         	_s3Client?.Dispose();

--- a/src/StorageLibrary/Azure/AzureContainer.cs
+++ b/src/StorageLibrary/Azure/AzureContainer.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
 
 using StorageLibrary.Common;
 using StorageLibrary.Interfaces;
@@ -48,11 +50,11 @@ namespace StorageLibrary.Azure
 				{
 					BlobClient blobClient = container.GetBlobClient(blobItem.Blob.Name);
 
-					wrapper = new BlobItemWrapper(blobClient.Uri.AbsoluteUri, blobItem.Blob.Properties.ContentLength.HasValue ? blobItem.Blob.Properties.ContentLength.Value : 0, CloudProvider.Azure, IsAzurite);
+					wrapper = new BlobItemWrapper(blobClient.Uri.AbsoluteUri, containerName, blobItem.Blob.Name, true, blobItem.Blob.Properties.ContentLength.HasValue ? blobItem.Blob.Properties.ContentLength.Value : 0, CloudProvider.Azure);
 				}
 				else if (blobItem.IsPrefix)
 				{
-					wrapper = new BlobItemWrapper($"{container.Uri}/{blobItem.Prefix}", 0, CloudProvider.Azure, IsAzurite);
+					wrapper = new BlobItemWrapper($"{container.Uri}/{blobItem.Prefix}", containerName, blobItem.Prefix, false, 0, CloudProvider.Azure);
 				}
 
 				if (wrapper != null && !results.Contains(wrapper))
@@ -95,6 +97,29 @@ namespace StorageLibrary.Azure
 			string tmpPath = Util.File.GetTempFileName();
 			await blob.DownloadToAsync(tmpPath);
 			return tmpPath;
+		}
+
+		public Task<string> GetBlobUploadUrlAsync(string containerName, string blobName, TimeSpan validFor)
+		{
+			BlobContainerClient container = ServiceClient.GetBlobContainerClient(containerName);
+			BlobClient blob = container.GetBlobClient(blobName);
+
+			// Only true when the client holds a shared key credential. Accounts reached
+			// through a SAS cannot sign a new one, so the caller falls back to uploading
+			// through the server.
+			if (!blob.CanGenerateSasUri)
+				return Task.FromResult<string>(null);
+
+			BlobSasBuilder builder = new BlobSasBuilder(BlobSasPermissions.Create | BlobSasPermissions.Write, DateTimeOffset.UtcNow.Add(validFor))
+			{
+				BlobContainerName = containerName,
+				BlobName = blobName,
+				Resource = "b",
+				StartsOn = DateTimeOffset.UtcNow.AddMinutes(-5), // tolerate clock skew
+				Protocol = IsAzurite ? SasProtocol.HttpsAndHttp : SasProtocol.Https
+			};
+
+			return Task.FromResult(blob.GenerateSasUri(builder).ToString());
 		}
 	}
 }

--- a/src/StorageLibrary/Azure/AzureFile.cs
+++ b/src/StorageLibrary/Azure/AzureFile.cs
@@ -42,13 +42,17 @@ namespace StorageLibrary.Azure
 
 			List<FileShareItemWrapper> items = new List<FileShareItemWrapper>();
 
+			// The listing only reports leaf names, so the parent has to come from what we were
+			// asked for. Trimmed because callers are inconsistent about the trailing slash.
+			string parent = string.IsNullOrWhiteSpace(folder) ? string.Empty : $"{folder.Trim('/')}/";
+
 			var files = dir.GetFilesAndDirectoriesAsync();
 			await foreach (var file in files)
 			{
 				var uriBuilder = new UriBuilder(dir.Uri);
 				uriBuilder.Path += $"/{file.Name}";
 				var uri = uriBuilder.Uri;
-				items.Add(new FileShareItemWrapper(uri.AbsoluteUri, !file.IsDirectory, file.FileSize));
+				items.Add(new FileShareItemWrapper(uri.AbsoluteUri, share, $"{parent}{file.Name}", !file.IsDirectory, file.FileSize));
 			}
 
 			return items;

--- a/src/StorageLibrary/Common/BlobItemWrapper.cs
+++ b/src/StorageLibrary/Common/BlobItemWrapper.cs
@@ -1,16 +1,19 @@
-﻿using System;
-using System.Web;
+using System;
 
 namespace StorageLibrary.Common
 {
 	public class BlobItemWrapper : IEquatable<BlobItemWrapper>, IComparable<BlobItemWrapper>
 	{
 		Uri m_internalUri;
-		bool m_isAzurite = false;
 		public string Name { get; private set; }
 		public string Path { get; private set; }
 		public string Container { get; private set; }
-		public string FullName { get => $"{Path}{Name}"; }
+
+		/// <summary>
+		/// The blob's name relative to its container, exactly as the provider reported it.
+		/// This is what every read/delete call expects back.
+		/// </summary>
+		public string FullName { get; private set; }
 		public bool IsFile { get; private set; }
 		public string Url
 		{
@@ -26,37 +29,22 @@ namespace StorageLibrary.Common
 
 		public decimal SizeInMBs { get => (decimal)Size / 1024 / 1024; }
 
-		public BlobItemWrapper(string url) : this(url, 0, CloudProvider.Azure) { }
-
-		public BlobItemWrapper(string url, long size, CloudProvider provider, bool fromAzurite = false)
+		/// <summary>
+		/// The URL is kept only for display and equality; it is never parsed. Container,
+		/// name and kind come from the caller, which already has them - deriving them from
+		/// the URL cannot be done reliably, since the account name sits in the host for
+		/// Azure and in the path for Azurite, and names may be percent-encoded.
+		/// </summary>
+		public BlobItemWrapper(string url, string container, string fullName, bool isFile, long size, CloudProvider provider)
 		{
 			Url = url;
+			Container = container;
+			FullName = fullName;
+			IsFile = isFile;
 			Size = size;
 			Provider = provider;
-			m_isAzurite = fromAzurite;
-			IsFile = !m_internalUri.Segments[m_internalUri.Segments.Length - 1].EndsWith(System.IO.Path.AltDirectorySeparatorChar);
-			Name = HttpUtility.UrlDecode(m_internalUri.Segments[m_internalUri.Segments.Length - 1]);
 
-			switch (provider)
-			{
-				case CloudProvider.Azure:
-					Container = m_isAzurite ? m_internalUri.Segments[2] : m_internalUri.Segments[1];
-					int containerPos = m_internalUri.LocalPath.IndexOf(Container) + Container.Length;
-					Path = m_internalUri.LocalPath.Substring(containerPos, (m_internalUri.LocalPath.Length) - (containerPos) - Name.Length);
-					break;
-				case CloudProvider.AWS:
-					Container = m_internalUri.Host.Split('.')[0];
-					Path = m_internalUri.LocalPath.Substring(1, m_internalUri.LocalPath.Length - 1 - Name.Length);
-					break;
-				case CloudProvider.GCP:
-					Container = m_internalUri.Segments[1];
-					int bucketPos = m_internalUri.LocalPath.IndexOf(Container) + Container.Length;
-					Path = m_internalUri.LocalPath.Substring(bucketPos, (m_internalUri.LocalPath.Length) - (bucketPos) - Name.Length);
-					break;
-				default:
-					throw new ApplicationException($"Invalid provider: {provider}");
-			}
-
+			(Path, Name) = StorageItemName.Split(fullName);
 		}
 
 		public int CompareTo(BlobItemWrapper other)

--- a/src/StorageLibrary/Common/FileShareItemWrapper.cs
+++ b/src/StorageLibrary/Common/FileShareItemWrapper.cs
@@ -1,15 +1,18 @@
-﻿using System;
-using System.Web;
+using System;
 
 namespace StorageLibrary.Common
 {
 	public class FileShareItemWrapper : IEquatable<FileShareItemWrapper>, IComparable<FileShareItemWrapper>
 	{
 		Uri m_internalUri;
-		public string Name { get => HttpUtility.UrlDecode(m_internalUri.Segments[m_internalUri.Segments.Length - 1]); }
-		public string Path { get => m_internalUri.LocalPath.Substring(FileShare.Length + 1, m_internalUri.LocalPath.Length - FileShare.Length - Name.Length - 1); }
-		public string FileShare { get => m_internalUri.Segments[1]; }
-		public string FullName { get => $"{Path}{Name}"; }
+		public string Name { get; private set; }
+		public string Path { get; private set; }
+		public string FileShare { get; private set; }
+
+		/// <summary>
+		/// The item's name relative to its share, exactly as the provider reported it.
+		/// </summary>
+		public string FullName { get; private set; }
 		public string Url
 		{
 			get { return m_internalUri.OriginalString; }
@@ -20,11 +23,19 @@ namespace StorageLibrary.Common
 		public decimal SizeInKBs { get => (decimal)Size / 1024; }
 		public decimal SizeInMBs { get => (decimal)Size / 1024 / 1024; }
 
-		public FileShareItemWrapper(string url, bool isFile, long? size)
+		/// <summary>
+		/// The URL is kept only for display and equality; it is never parsed. See
+		/// <see cref="BlobItemWrapper"/> for why the caller supplies the identity instead.
+		/// </summary>
+		public FileShareItemWrapper(string url, string fileShare, string fullName, bool isFile, long? size)
 		{
 			Url = url;
-			Size = size.HasValue ? size.Value : 0;
+			FileShare = fileShare;
+			FullName = fullName;
 			IsFile = isFile;
+			Size = size.HasValue ? size.Value : 0;
+
+			(Path, Name) = StorageItemName.Split(fullName);
 		}
 
 		public int CompareTo(FileShareItemWrapper other)

--- a/src/StorageLibrary/Common/StorageItemName.cs
+++ b/src/StorageLibrary/Common/StorageItemName.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace StorageLibrary.Common
+{
+	/// <summary>
+	/// Splits the name a storage provider gives us into a parent path and a leaf, so the
+	/// item wrappers never have to reconstruct identity by parsing a URL. URLs differ per
+	/// provider and per endpoint style (the account name lives in the host on Azure but in
+	/// the path on Azurite), while the name is always the same string we need to hand back
+	/// when reading, downloading or deleting the item.
+	/// </summary>
+	internal static class StorageItemName
+	{
+		/// <summary>
+		/// "a/b/c.txt" -> ("a/b/", "c.txt"), "a/b/" -> ("a/", "b/"), "c.txt" -> ("", "c.txt").
+		/// Concatenating the two halves always reproduces <paramref name="fullName"/>.
+		/// </summary>
+		internal static (string Path, string Name) Split(string fullName)
+		{
+			if (string.IsNullOrEmpty(fullName))
+				return (string.Empty, string.Empty);
+
+			// Length-2 so a trailing slash stays attached to the leaf: blob prefixes are named
+			// "folder/", and both the folder list and the prefix query depend on keeping it.
+			int slash = fullName.LastIndexOf('/', Math.Max(fullName.Length - 2, 0));
+
+			return slash < 0
+				? (string.Empty, fullName)
+				: (fullName.Substring(0, slash + 1), fullName.Substring(slash + 1));
+		}
+	}
+}

--- a/src/StorageLibrary/GCP/GCPBucket.cs
+++ b/src/StorageLibrary/GCP/GCPBucket.cs
@@ -117,7 +117,7 @@ namespace StorageLibrary.Google
 			var listObjects = await listRequest.ExecuteAsync();
 
 			List<BlobItemWrapper> blobs = new List<BlobItemWrapper>();
-			string uriTemplate = $"https://storage.cloud.google.com/sebagomeztestbucket/";
+			string uriTemplate = $"https://storage.cloud.google.com/{bucket}/";
 			if (listObjects.Items != null)
 			{
 				foreach (var obj in listObjects.Items)
@@ -125,13 +125,13 @@ namespace StorageLibrary.Google
 					if (obj.Name == path)
 						continue;
 
-					blobs.Add(new BlobItemWrapper($"{uriTemplate}{obj.Name}", (long)obj.Size, CloudProvider.GCP));
+					blobs.Add(new BlobItemWrapper($"{uriTemplate}{obj.Name}", bucket, obj.Name, true, (long)obj.Size, CloudProvider.GCP));
 				}
 			}
 
 			if (listObjects.Prefixes != null)
 				foreach (string commonPrefix in listObjects.Prefixes)
-					blobs.Add(new BlobItemWrapper($"{uriTemplate}{commonPrefix}", 0, CloudProvider.GCP));
+					blobs.Add(new BlobItemWrapper($"{uriTemplate}{commonPrefix}", bucket, commonPrefix, false, 0, CloudProvider.GCP));
 
 			return blobs;
 		}
@@ -151,6 +151,13 @@ namespace StorageLibrary.Google
 			}
 
 			return containers;
+		}
+
+		// Signed PUT URLs (UrlSigner) are not wired up yet; callers fall back to
+		// uploading through the server.
+		public Task<string> GetBlobUploadUrlAsync(string bucket, string objectName, TimeSpan validFor)
+		{
+			return Task.FromResult<string>(null);
 		}
 
 		public void Dispose()

--- a/src/StorageLibrary/Interfaces/IContainer.cs
+++ b/src/StorageLibrary/Interfaces/IContainer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -15,5 +16,12 @@ namespace StorageLibrary.Interfaces
 		Task DeleteBlobAsync(string containerName, string blobName);
 		Task CreateBlobAsync(string containerName, string blobName, Stream fileContent);
 		Task<string> GetBlobAsync(string containerName, string blobName);
+		/// <summary>
+		/// Gets a pre-signed URL the browser can upload a single blob to directly,
+		/// bypassing the server. Returns null when the provider or the current
+		/// credentials cannot sign one, in which case the caller must upload through
+		/// <see cref="CreateBlobAsync"/> instead.
+		/// </summary>
+		Task<string> GetBlobUploadUrlAsync(string containerName, string blobName, TimeSpan validFor);
 	}
 }

--- a/src/StorageLibrary/Mocks/MockContainer.cs
+++ b/src/StorageLibrary/Mocks/MockContainer.cs
@@ -30,8 +30,8 @@ namespace StorageLibrary.Mocks
 					throw new NullReferenceException($"Container '{containerName}' does not exist");
 
 				List<BlobItemWrapper> results = new List<BlobItemWrapper>();
-				foreach(string url in MockUtils.GetItems(containerName, path))
-					results.Add(new BlobItemWrapper(url, MockUtils.NewRandomSize, CloudProvider.Azure));
+				foreach(string blobName in MockUtils.GetItems(containerName, path))
+					results.Add(new BlobItemWrapper($"{MockUtils.FAKE_URL}/{containerName}/{blobName}", containerName, blobName, !blobName.EndsWith("/"), MockUtils.NewRandomSize, CloudProvider.Azure));
 
 				return results;
 			});
@@ -72,11 +72,11 @@ namespace StorageLibrary.Mocks
 				if (MockUtils.FolderStructure[containerName].Contains(blobName))
 					throw new InvalidOperationException($"Blob '{blobName}' already exists in Container '{containerName}'");
 
-				BlobItemWrapper blob = StorageFactory.GetBlobItemWrapper($"{MockUtils.FAKE_URL}/{containerName}/{blobName}");
-				if (!MockUtils.FolderStructure[containerName].Contains(blob.Path))
-					MockUtils.FolderStructure[containerName].Add(blob.Path);
+				(string path, _) = StorageItemName.Split(blobName);
+				if (!string.IsNullOrEmpty(path) && !MockUtils.FolderStructure[containerName].Contains(path))
+					MockUtils.FolderStructure[containerName].Add(path);
 
-				MockUtils.FolderStructure[containerName].Add(blob.FullName);
+				MockUtils.FolderStructure[containerName].Add(blobName);
 			});
 		}
 
@@ -103,6 +103,12 @@ namespace StorageLibrary.Mocks
 
 				MockUtils.FolderStructure.Remove(containerName);
 			});
+		}
+
+		// There is nothing to upload to; callers fall back to CreateBlobAsync.
+		public Task<string> GetBlobUploadUrlAsync(string containerName, string blobName, TimeSpan validFor)
+		{
+			return Task.FromResult<string>(null);
 		}
 	}
 }

--- a/src/StorageLibrary/Mocks/MockFile.cs
+++ b/src/StorageLibrary/Mocks/MockFile.cs
@@ -100,8 +100,8 @@ namespace StorageLibrary.Mocks
 					throw new NullReferenceException($"Share '{share}' does not exist");
 
 				List<FileShareItemWrapper> results = new List<FileShareItemWrapper>();
-				foreach(string url in MockUtils.GetItems(share, folder))
-					results.Add(new FileShareItemWrapper(url, !url.EndsWith("/"), MockUtils.NewRandomSize));
+				foreach(string itemName in MockUtils.GetItems(share, folder))
+					results.Add(new FileShareItemWrapper($"{MockUtils.FAKE_URL}/{share}/{itemName}", share, itemName, !itemName.EndsWith("/"), MockUtils.NewRandomSize));
 
 				return results;
 			});

--- a/src/StorageLibrary/Mocks/MockUtils.cs
+++ b/src/StorageLibrary/Mocks/MockUtils.cs
@@ -34,6 +34,10 @@ namespace StorageLibrary.Mocks
 
 		public static Dictionary<string, List<string>> FolderStructure { get => s_folderStructure; }
 
+		/// <summary>
+		/// Yields the names of the items directly under <paramref name="folder"/>, relative to
+		/// the container/share. Callers build whatever URL they need from them.
+		/// </summary>
 		public static IEnumerable<string> GetItems(string key, string folder)
 		{
 			foreach (string val in MockUtils.FolderStructure[key])
@@ -65,14 +69,14 @@ namespace StorageLibrary.Mocks
 					}
 
 					if (inCurrentDir)
-						yield return $"{MockUtils.FAKE_URL}/{key}/{val}";
+						yield return val;
 				}
 				else
 				{
 					if (dirs.Length > 1)
 						continue;
 
-					yield return $"{MockUtils.FAKE_URL}/{key}/{val}";
+					yield return val;
 				}
 			}
 		}

--- a/src/StorageLibrary/StorageFactory.cs
+++ b/src/StorageLibrary/StorageFactory.cs
@@ -12,14 +12,10 @@ namespace StorageLibrary
 {
 	public class StorageFactory
 	{
-		static StorageFactory Instance;
-
 		public IQueue Queues { get; private set; }
 		public IContainer Containers { get; set; }
 		public ITable Tables { get; set; }
 		public IFile Files { get; set; }
-
-		StorageFactoryConfig m_currentConfig;
 
 		public StorageFactory()
 		: this(new StorageFactoryConfig { Mock = true })
@@ -27,7 +23,6 @@ namespace StorageLibrary
 
 		public StorageFactory(StorageFactoryConfig config)
 		{
-			m_currentConfig = config;
 			if (config.Mock)
 			{
 				Queues = new MockQueue();
@@ -55,13 +50,6 @@ namespace StorageLibrary
 						throw new ApplicationException($"Invalid provider: {config.Provider}");
 				}
 			}
-
-			Instance = this;
-		}
-
-		public static BlobItemWrapper GetBlobItemWrapper(string url, long size = 0)
-		{
-			return new BlobItemWrapper(url, size, Instance.m_currentConfig.Provider, Instance.m_currentConfig.IsAzurite);
 		}
 	}
 

--- a/src/TestDockerfile
+++ b/src/TestDockerfile
@@ -1,0 +1,34 @@
+# Runs the unit tests in a container, so they don't depend on a working local SDK.
+#
+# The context must be the repo root, because StorageLibTests.csproj references
+# ../../src/StorageLibrary - a ./src context cannot reach tests/:
+#
+#   docker build -f src/TestDockerfile -t azurestorageexplorer-tests:local .
+#   docker run --rm azurestorageexplorer-tests:local
+#
+# Extra dotnet test arguments are appended to the run, e.g.
+#   docker run --rm azurestorageexplorer-tests:local --filter ClassName~ContainersTests
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+WORKDIR /repo
+
+COPY src/ ./src/
+COPY tests/ ./tests/
+
+# There is no .dockerignore at the repo root, so the host's obj/ and bin/ come along
+# with the copy. Their assets files hold absolute host paths and a possibly different
+# SDK version, which makes restore fail or silently reuse stale output - so start clean.
+RUN find . -type d \( -name obj -o -name bin \) -prune -exec rm -rf {} +
+
+# Restore and compile at image build time: a compile error then fails the build, and
+# each `docker run` only has to execute the tests.
+RUN dotnet restore ./tests/StorageLibTests/StorageLibTests.csproj
+RUN dotnet build ./tests/StorageLibTests/StorageLibTests.csproj --no-restore
+
+# The tests drive the in-memory mocks (the parameterless StorageFactory sets Mock=true),
+# so no credentials, no Azurite, no environment variables are needed.
+#
+# ENTRYPOINT rather than RUN so a failing test is a non-zero `docker run` exit code
+# instead of an unbuildable image, and so the suite can be re-run without rebuilding.
+ENTRYPOINT ["dotnet", "test", "./tests/StorageLibTests/StorageLibTests.csproj", "--no-build"]

--- a/src/web/App.razor
+++ b/src/web/App.razor
@@ -29,7 +29,11 @@
     <script>
         window.downloadFileFromStream = async (fileName, contentStreamReference) => {
             const arrayBuffer = await contentStreamReference.arrayBuffer();
-            const blob = new Blob([arrayBuffer]);
+            // The type is explicit on purpose: an untyped Blob is sniffed as text/plain,
+            // and when the download name has no extension the browser appends one from
+            // the type - so an extensionless blob would be saved as "<name>.txt".
+            // application/octet-stream has no canonical extension, so the name is kept verbatim.
+            const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
             const url = URL.createObjectURL(blob);
             const anchorElement = document.createElement('a');
             anchorElement.href = url;
@@ -37,6 +41,51 @@
             anchorElement.click();
             anchorElement.remove();
             URL.revokeObjectURL(url);
+        }
+
+        // Uploads the file currently selected in inputEl straight to storage, so the
+        // bytes never cross the Blazor circuit. Reports 'retryable' when the request
+        // never reached storage (CORS preflight refused, offline, DNS) so the caller
+        // can safely fall back to uploading through the server.
+        // XMLHttpRequest rather than fetch: only xhr exposes upload progress events.
+        window.uploadBlobToSasUrl = (inputEl, url, progress) => {
+            const file = inputEl?.files?.[0];
+            if (!file)
+                return Promise.resolve({ ok: false, retryable: false, status: 0, error: 'No file selected' });
+
+            return new Promise(resolve => {
+                const xhr = new XMLHttpRequest();
+                xhr.open('PUT', url, true);
+                xhr.setRequestHeader('x-ms-blob-type', 'BlockBlob');
+                xhr.setRequestHeader('If-None-Match', '*');
+                xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
+
+                // Report whole percentages only, to keep circuit chatter bounded.
+                let reported = -1;
+                xhr.upload.onprogress = e => {
+                    if (!progress || !e.lengthComputable)
+                        return;
+
+                    const percent = Math.floor((e.loaded / e.total) * 100);
+                    if (percent !== reported) {
+                        reported = percent;
+                        progress.invokeMethodAsync('ReportUploadProgress', percent);
+                    }
+                };
+
+                xhr.onload = () => resolve({
+                    ok: xhr.status >= 200 && xhr.status < 300,
+                    retryable: false,
+                    status: xhr.status,
+                    error: xhr.statusText
+                });
+
+                // Fires for CORS refusals too, which is exactly what should fall back.
+                xhr.onerror = () => resolve({ ok: false, retryable: true, status: 0, error: 'network error' });
+                xhr.onabort = () => resolve({ ok: false, retryable: true, status: 0, error: 'aborted' });
+
+                xhr.send(file);
+            });
         }
     </script>
 </body>

--- a/src/web/Directory.Build.props
+++ b/src/web/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <AzureStorageWebExplorerVersion>3.3.0</AzureStorageWebExplorerVersion>
+    <AzureStorageWebExplorerVersion>4.0.0</AzureStorageWebExplorerVersion>
   </PropertyGroup>
 </Project>

--- a/src/web/Pages/Blobs.razor
+++ b/src/web/Pages/Blobs.razor
@@ -1,6 +1,19 @@
 @inherits web.Pages.BaseComponent
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
+
+@if (Uploading)
+{
+	<div class="web-upload">
+		@if (UploadPercent >= 0)
+		{
+			<div class="ui small blue progress">
+				<div class="bar" style="width:@UploadPercent%"></div>
+			</div>
+		}
+		<em>@UploadStatus</em>
+	</div>
+}
 
 @if (CurrentContainer is null)
 {
@@ -20,9 +33,9 @@ else
 			<th style="min-width: 100px" >@CurrentPath</th>
 			<th>
 				<div style="display:flex;justify-content: space-around;">
-					<InputFile class="ui button" OnChange="@LoadFile"/>
+					<InputFile @ref="BlobFileInput" class="ui button" OnChange="@LoadFile"/>
 					<input @bind-value="UploadFolder" placeholder="Upload to folder" />
-					<button class="ui button" type="button" @onclick="UploadBlob">Upload</button>
+					<button class="ui button @(Uploading ? "loading disabled" : "")" type="button" @onclick="UploadBlob">Upload</button>
 				</div>
 			</th>
 			<th>
@@ -50,7 +63,7 @@ else
 	@foreach (var Folder in AzureContainerFolders)
 	{
 		<tr>
-			<td colspan="3" class="table-text"><a class="link" @onclick="@(e => EnterFolder(e, Folder.Url))">@Folder.Name</a></td>
+			<td colspan="3" class="table-text"><a class="link" @onclick="@(e => EnterFolder(e, Folder))">@Folder.Name</a></td>
 			<td style="display:none">@Folder.Url</td>
 		</tr>
 	}
@@ -73,8 +86,8 @@ else
 					<div class="ui simple dropdown item">
 						<i class="ellipsis vertical icon"></i>
 						<div class="menu">
-							<div class="item" @onclick="@(e => DownloadBlob(e, Blob.Url))"><i class="download icon"></i>Download</div>
-							<div class="red item" style="color: firebrick !important;" @onclick="@(e => DeleteBlob(e, Blob.Url))">
+							<div class="item" @onclick="@(e => DownloadBlob(e, Blob))"><i class="download icon"></i>Download</div>
+							<div class="red item" style="color: firebrick !important;" @onclick="@(e => DeleteBlob(e, Blob))">
 								<i class="trash icon"></i>Delete
 							</div>
 						</div>

--- a/src/web/Pages/Blobs.razor.cs
+++ b/src/web/Pages/Blobs.razor.cs
@@ -22,6 +22,28 @@ namespace web.Pages
 
 		public IBrowserFile? FileToUpload { get; set; }
 
+		// Needed to hand the underlying <input type="file"> to JS so the browser can
+		// upload the bytes directly instead of streaming them through the circuit.
+		protected InputFile? BlobFileInput { get; set; }
+
+		static readonly TimeSpan SAS_LIFETIME = TimeSpan.FromMinutes(15);
+
+		public bool Uploading { get; set; } = false;
+
+		/// <summary>Percent uploaded, or -1 when the transfer cannot report progress.</summary>
+		public int UploadPercent { get; set; } = -1;
+
+		public string UploadStatus
+		{
+			get
+			{
+				string name = FileToUpload?.Name ?? "file";
+				return UploadPercent < 0
+					? $"Uploading {name} through the server..."
+					: $"Uploading {name}... {UploadPercent}%";
+			}
+		}
+
 		public bool ShowTable { get; set; } = false;
 
 		public string Plural { get => FileCount == 1 ? "object" : "objects"; }
@@ -100,9 +122,8 @@ namespace web.Pages
 			await LoadBlobs();
 		}
 
-		public async Task EnterFolder(EventArgs args, string blobUrl)
+		public async Task EnterFolder(EventArgs args, BlobItemWrapper blob)
 		{
-			BlobItemWrapper blob = StorageFactory.GetBlobItemWrapper(blobUrl);
 			if (blob.IsFile)
 				return;
 
@@ -113,12 +134,11 @@ namespace web.Pages
 			await LoadBlobs();
 		}
 
-		public async Task DownloadBlob(EventArgs args, string blobUrl)
+		public async Task DownloadBlob(EventArgs args, BlobItemWrapper blob)
 		{
 			string path = "";
 			try
 			{
-				BlobItemWrapper blob = StorageFactory.GetBlobItemWrapper(blobUrl);
 				path = await AzureStorage!.Containers.GetBlobAsync(CurrentContainer, blob.FullName);
 
 				FileStream fileStream = File.OpenRead(path);
@@ -140,11 +160,10 @@ namespace web.Pages
 			}
 		}
 
-		public async Task DeleteBlob(EventArgs args, string blobUrl)
+		public async Task DeleteBlob(EventArgs args, BlobItemWrapper blob)
 		{
 			try
 			{
-				BlobItemWrapper blob = StorageFactory.GetBlobItemWrapper(blobUrl);
 				await AzureStorage!.Containers.DeleteBlobAsync(CurrentContainer, blob.FullName);
 				await LoadBlobs();
 			}
@@ -157,23 +176,107 @@ namespace web.Pages
 
 		public async Task UploadBlob()
 		{
+			if (Uploading)
+				return;
+
+			if (FileToUpload is null)
+			{
+				HasError = true;
+				ErrorMessage = "No file selected";
+				return;
+			}
+
 			try
 			{
 				if (!string.IsNullOrEmpty(UploadFolder) && !UploadFolder.EndsWith("/"))
 					UploadFolder += "/";
 
-				using (Stream fileStream = FileToUpload!.OpenReadStream(Util.MAX_UPLOAD_SIZE))
-					await AzureStorage!.Containers.CreateBlobAsync(CurrentContainer, $"{UploadFolder}{FileToUpload!.Name}", fileStream);
+				string blobName = $"{UploadFolder}{FileToUpload!.Name}";
+
+				Uploading = true;
+				UploadPercent = -1;
+				StateHasChanged();
+
+				if (!await TryDirectUploadAsync(blobName))
+					await ProxyUploadAsync(blobName);
 
 				UploadFolder = string.Empty;
+				Uploading = false; // the refresh below has its own indicator
 				await LoadBlobs();
 			}
 			catch (Exception ex)
 			{
 				HasError = true;
-				ErrorMessage = ex.Message;
+				ErrorMessage = Util.RedactSignatures(ex.Message);
+			}
+			finally
+			{
+				Uploading = false;
+				UploadPercent = -1;
 			}
 		}
+
+		/// <summary>
+		/// Called from JS as the upload advances. Marshalled onto the renderer's
+		/// synchronization context so the progress bar actually repaints.
+		/// </summary>
+		[JSInvokable]
+		public async Task ReportUploadProgress(int percent)
+		{
+			UploadPercent = percent;
+			await InvokeAsync(StateHasChanged);
+		}
+
+		/// <summary>
+		/// Uploads straight from the browser to storage using a short lived SAS, keeping
+		/// the bytes off the Blazor circuit. Returns false when the upload could not be
+		/// attempted or never reached storage, meaning the caller should proxy instead.
+		/// </summary>
+		private async Task<bool> TryDirectUploadAsync(string blobName)
+		{
+			if (BlobFileInput?.Element is null)
+				return false;
+
+			string url = await AzureStorage!.Containers.GetBlobUploadUrlAsync(CurrentContainer!, blobName, SAS_LIFETIME);
+			if (string.IsNullOrEmpty(url))
+				return false; // these credentials cannot sign an upload URL
+
+			UploadPercent = 0;
+			using DotNetObjectReference<Blobs> progress = DotNetObjectReference.Create(this);
+			UploadResult result = await JS!.InvokeAsync<UploadResult>("uploadBlobToSasUrl", BlobFileInput.Element, url, progress);
+
+			if (result.Ok)
+				return true;
+
+			if (result.Retryable)
+				return false; // never reached storage (CORS, offline) - safe to proxy
+
+			// Storage answered and refused; proxying would fail the same way.
+			throw new InvalidOperationException(DescribeFailure(result, blobName));
+		}
+
+		private async Task ProxyUploadAsync(string blobName)
+		{
+			// No per-byte progress available on this path.
+			UploadPercent = -1;
+			await InvokeAsync(StateHasChanged);
+
+			if (FileToUpload!.Size > Util.MAX_UPLOAD_SIZE)
+				throw new InvalidOperationException(
+					$"Direct upload to storage is unavailable (the account most likely has no CORS rule for this site) and '{FileToUpload.Name}' is larger than the {Util.MAX_UPLOAD_SIZE / (1024 * 1024)} MB limit for uploads routed through the server.");
+
+			using Stream fileStream = FileToUpload.OpenReadStream(Util.MAX_UPLOAD_SIZE);
+			await AzureStorage!.Containers.CreateBlobAsync(CurrentContainer, blobName, fileStream);
+		}
+
+		private static string DescribeFailure(UploadResult result, string blobName) => result.Status switch
+		{
+			409 or 412 => $"Blob '{blobName}' already exists",
+			403 => "Storage rejected the upload as unauthorized; the signature may have expired",
+			_ => $"Upload failed with status {result.Status}{(string.IsNullOrEmpty(result.Error) ? "" : $" ({Util.RedactSignatures(result.Error)})")}"
+		};
+
+		private sealed record UploadResult(bool Ok, bool Retryable, int Status, string? Error);
 
 		public Task LoadFile(InputFileChangeEventArgs args)
 		{

--- a/src/web/Pages/Containers.razor
+++ b/src/web/Pages/Containers.razor
@@ -5,7 +5,7 @@
 
 <BaseComponent Selected="Containers" />
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 <p></p>
 

--- a/src/web/Pages/Files.razor
+++ b/src/web/Pages/Files.razor
@@ -1,6 +1,6 @@
 @inherits web.Pages.BaseComponent
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 
 @if (CurrentFileShare is null)
@@ -56,7 +56,7 @@ else
 	@foreach (var dir in AzureFileShareDirectories)
 	{
 		<tr>
-			<td colspan="4" class="table-text"><a class="link" @onclick="@(e => EnterFolder(e, dir.Url))">@dir.Name</a></td>
+			<td colspan="4" class="table-text"><a class="link" @onclick="@(e => EnterFolder(e, dir))">@dir.Name</a></td>
 			<td style="display:none">@dir.Url</td>
 		</tr>
 	}
@@ -79,8 +79,8 @@ else
 					<div class="ui simple dropdown item">
 						<i class="ellipsis vertical icon"></i>
 						<div class="menu">
-							<div class="item" @onclick="@(e => DownloadFile(e, file.Url))"><i class="download icon"></i>Download</div>
-							<div class="red item" style="color: firebrick !important;" @onclick="@(e => DeleteFile(e, file.Url))">
+							<div class="item" @onclick="@(e => DownloadFile(e, file))"><i class="download icon"></i>Download</div>
+							<div class="red item" style="color: firebrick !important;" @onclick="@(e => DeleteFile(e, file))">
 								<i class="trash icon"></i>Delete
 							</div>
 						</div>

--- a/src/web/Pages/Files.razor.cs
+++ b/src/web/Pages/Files.razor.cs
@@ -71,6 +71,13 @@ namespace web.Pages
 
 		public async Task UploadFile()
 		{
+			if (FileToUpload is null)
+			{
+				HasError = true;
+				ErrorMessage = "No file selected";
+				return;
+			}
+
 			try
 			{
 				using (Stream fileStream = FileToUpload!.OpenReadStream(Util.MAX_UPLOAD_SIZE))
@@ -106,7 +113,9 @@ namespace web.Pages
 
 		public async Task MoveUp()
 		{
-			int parentSlash = CurrentPath.LastIndexOf("/", CurrentPath.Length - 2);
+			// Max() because a file-share CurrentPath has no trailing slash, so it can be a
+			// single character - Length-2 would then be a negative start index.
+			int parentSlash = CurrentPath.LastIndexOf("/", Math.Max(CurrentPath.Length - 2, 0));
 			if (parentSlash < 0)
 				CurrentPath = "";
 			else
@@ -116,9 +125,8 @@ namespace web.Pages
 			await LoadFiles();
 		}
 
-		public async Task EnterFolder(EventArgs args, string fileUrl)
+		public async Task EnterFolder(EventArgs args, FileShareItemWrapper file)
 		{
-			FileShareItemWrapper file = new FileShareItemWrapper(fileUrl, false, null);
 			CurrentPath = file.FullName;
 
 			StateHasChanged();
@@ -142,12 +150,11 @@ namespace web.Pages
 			}
 		}
 
-		public async Task DownloadFile(EventArgs args, string url)
+		public async Task DownloadFile(EventArgs args, FileShareItemWrapper file)
 		{
 			string path = "";
 			try
 			{
-				FileShareItemWrapper file = new FileShareItemWrapper(url, true, 0);
 				path = await AzureStorage!.Files.GetFileAsync(CurrentFileShare, file.Name, file.Path);
 
 				FileStream fileStream = File.OpenRead(path);
@@ -170,12 +177,10 @@ namespace web.Pages
 
 		}
 
-		public async Task DeleteFile(EventArgs args, string url)
+		public async Task DeleteFile(EventArgs args, FileShareItemWrapper file)
 		{
 			try
 			{
-				FileShareItemWrapper file = new FileShareItemWrapper(url, true, 0);
-
 				await AzureStorage!.Files.DeleteFileAsync(CurrentFileShare, file.Name, file.Path);
 				await LoadFiles();
 			}

--- a/src/web/Pages/QMessages.razor
+++ b/src/web/Pages/QMessages.razor
@@ -1,6 +1,6 @@
 @inherits web.Pages.BaseComponent
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 
 @if (CurrentQueue is null)

--- a/src/web/Pages/Queues.razor
+++ b/src/web/Pages/Queues.razor
@@ -5,7 +5,7 @@
 
 <BaseComponent Selected="Queues" />
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 <p></p>
 

--- a/src/web/Pages/Shares.razor
+++ b/src/web/Pages/Shares.razor
@@ -5,7 +5,7 @@
 
 <BaseComponent Selected="FileShares" />
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 <p></p>
 

--- a/src/web/Pages/TableData.razor
+++ b/src/web/Pages/TableData.razor
@@ -1,6 +1,6 @@
 @inherits web.Pages.BaseComponent
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 <p></p>
 

--- a/src/web/Pages/Tables.razor
+++ b/src/web/Pages/Tables.razor
@@ -5,7 +5,7 @@
 
 <BaseComponent Selected="Tables" />
 
-<Error HasError=@HasError ErrorMessage=@ErrorMessage />
+<Error @bind-HasError="HasError" ErrorMessage=@ErrorMessage />
 
 <p></p>
 

--- a/src/web/Shared/Error.razor
+++ b/src/web/Shared/Error.razor
@@ -1,5 +1,8 @@
 
-	<div class="web-error-ui ui red message" style="display:none" @attributes="this.ErrorAtts">@ErrorMessage</div>
+	<div class="web-error-ui ui red message" style="@HiddenStyle">
+		<i class="dismiss close icon" title="Dismiss" @onclick="DismissAsync"></i>
+		@ErrorMessage
+	</div>
 
 
 @code
@@ -7,22 +10,18 @@
 	[Parameter]
 	public bool HasError { get; set; } = false;
 	[Parameter]
+	public EventCallback<bool> HasErrorChanged { get; set; }
+	[Parameter]
 	public string? ErrorMessage { get; set; }
 
-	private Dictionary<string, object> ErrorAtts = new Dictionary<string, object>();
+	// Kept in the DOM and hidden rather than removed: Semantic UI zeroes top margins
+	// via :first-child (.ui.table, .ui.menu, .ui.segment...), which is structural and
+	// ignores position:fixed, so adding/removing this element shifts the page content.
+	private string? HiddenStyle => HasError ? null : "display:none";
 
-	protected override async Task OnParametersSetAsync()
+	private async Task DismissAsync()
 	{
-		if (HasError && ErrorAtts.ContainsKey("style"))
-		{
-			ErrorAtts.Remove("style");
-			await Task.Delay(5 * 1000);
-			ErrorAtts.Add("style", "display:none");
-		}
-	}
-	protected override void OnInitialized()
-	{
-		if (! ErrorAtts.ContainsKey("style"))
-			ErrorAtts.Add("style", "display:none");
+		HasError = false;
+		await HasErrorChanged.InvokeAsync(false);
 	}
 }

--- a/src/web/Utils/Util.cs
+++ b/src/web/Utils/Util.cs
@@ -1,11 +1,22 @@
+using System.Text.RegularExpressions;
+
 using StorageLibrary;
 
 namespace web.Utils
 {
 	public class Util
 	{
-		const long MAX_MEGS = 10;
-		public const long MAX_UPLOAD_SIZE = 1024 * 1024 * MAX_MEGS;
+		const long DEFAULT_MAX_MEGS = 10;
+
+		/// <summary>
+		/// Cap on uploads routed through the server, in bytes. This only bounds what a
+		/// Blazor circuit will buffer - direct browser-to-storage uploads are unaffected.
+		/// Read once at startup from <see cref="MAX_SERVER_UPLOAD_MEGS"/>; anything that
+		/// is not a positive integer falls back to <see cref="DEFAULT_MAX_MEGS"/>.
+		/// </summary>
+		public static readonly long MAX_UPLOAD_SIZE = 1024 * 1024 * GetMaxUploadMegs();
+
+		public const string MAX_SERVER_UPLOAD_MEGS = "MAX_SERVER_UPLOAD_MEGS";
 		public const string AZURE_STORAGE_CONNECTIONSTRING = "AZURE_STORAGE_CONNECTIONSTRING";
 		public const string AZURE_STORAGE_ACCOUNT = "AZURE_STORAGE_ACCOUNT";
 		public const string AZURE_STORAGE_KEY = "AZURE_STORAGE_KEY";
@@ -15,6 +26,13 @@ namespace web.Utils
 
 		public static string Provider { get; set; } = "Azure";
 		public static bool Azurite { get; set; } = false;
+
+		static long GetMaxUploadMegs()
+		{
+			string? configured = Environment.GetEnvironmentVariable(MAX_SERVER_UPLOAD_MEGS);
+
+			return long.TryParse(configured, out long megs) && megs > 0 ? megs : DEFAULT_MAX_MEGS;
+		}
 
 		public static StorageFactory GetStorageFactory(Credentials cred)
 		{
@@ -40,6 +58,19 @@ namespace web.Utils
 				IsAzurite = Azurite, 
 				Mock = mockEnabled 
 			});
+		}
+
+		/// <summary>
+		/// Removes shared access signatures from text that is about to be shown to the
+		/// user or logged. A SAS in a URL *is* the credential, and storage exceptions
+		/// often embed the request URI.
+		/// </summary>
+		public static string RedactSignatures(string text)
+		{
+			if (string.IsNullOrEmpty(text))
+				return text;
+
+			return Regex.Replace(text, @"(?<=[?&]sig=)[^&\s""']+", "REDACTED", RegexOptions.IgnoreCase);
 		}
 	}
 }

--- a/src/web/wwwroot/css/azurewebexplorer.css
+++ b/src/web/wwwroot/css/azurewebexplorer.css
@@ -105,9 +105,10 @@
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
     left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem !important;
+    padding: 0.6rem 2.75rem 0.7rem 1.25rem !important;
     position: fixed !important; 
-    width: 100%;
+    right: 0;
+    width: auto;
     z-index: 1000;
 	margin: 10px !important;
 }
@@ -117,6 +118,21 @@
         position: absolute;
         right: 0.75rem;
         top: 0.5rem;
+    }
+
+.web-upload {
+    margin: 0.75rem 0;
+}
+
+    /* Semantic's defaults are 1em/2.5em margins and a 2em min-width on the bar,
+       which leaves a stub sitting at 0%. */
+    .web-upload .ui.progress {
+        margin: 0 0 0.35rem 0;
+    }
+
+    .web-upload .ui.progress .bar {
+        height: 0.9rem;
+        min-width: 0;
     }
 
 .link{

--- a/tests/StorageLibTests/ContainersTests.cs
+++ b/tests/StorageLibTests/ContainersTests.cs
@@ -22,11 +22,11 @@ namespace StorageLibTests
 		public async Task GetContainerBlobs()
 		{
 			string containerName = "one";
-			List<BlobItemWrapper> expected = new List<BlobItemWrapper> 
-			{ 
-				new BlobItemWrapper($"{MockUtils.FAKE_URL}/{containerName}/fromOne:1"), 
-				new BlobItemWrapper($"{MockUtils.FAKE_URL}/{containerName}/fromOne:2"),
-				new BlobItemWrapper($"{MockUtils.FAKE_URL}/{containerName}/fromOne:3")
+			List<string> expected = new List<string>
+			{
+				$"{MockUtils.FAKE_URL}/{containerName}/fromOne:1",
+				$"{MockUtils.FAKE_URL}/{containerName}/fromOne:2",
+				$"{MockUtils.FAKE_URL}/{containerName}/fromOne:3"
 			};
 
 			StorageFactory factory = new StorageFactory();
@@ -34,7 +34,54 @@ namespace StorageLibTests
 
 			Assert.HasCount(expected.Count, blobs, $"Different amount returned. {string.Join(",", blobs)}");
 			for	(int i = 0; i < expected.Count; i++)
-				Assert.AreEqual(blobs[i].Url, expected[i].Url, $"Different objecte returned. Expected '{expected[i].Url}' got '{blobs[i].Url}'");
+				Assert.AreEqual(blobs[i].Url, expected[i], $"Different objecte returned. Expected '{expected[i]}' got '{blobs[i].Url}'");
+		}
+
+		/// <summary>
+		/// The wrapper must hand back exactly the name the provider reported, split into a
+		/// parent path and a leaf. This used to be derived by parsing the URL, which broke
+		/// on path-style endpoints and on names needing percent-encoding.
+		/// </summary>
+		[TestMethod]
+		public async Task BlobNamesRoundTrip()
+		{
+			string containerName = "with-many-folders";
+
+			StorageFactory factory = new StorageFactory();
+			List<BlobItemWrapper> blobs = await factory.Containers.ListBlobsAsync(containerName, "folder1/");
+
+			// folder1/file1 and folder1/folder11/
+			Assert.HasCount(2, blobs, $"Unexpected listing for 'folder1/'. {string.Join(",", blobs)}");
+
+			foreach (BlobItemWrapper blob in blobs)
+			{
+				Assert.AreEqual(containerName, blob.Container, $"Wrong container for '{blob.FullName}'");
+				Assert.AreEqual(blob.FullName, $"{blob.Path}{blob.Name}", $"Path+Name does not reproduce FullName for '{blob.FullName}'");
+				Assert.AreEqual("folder1/", blob.Path, $"Wrong path for '{blob.FullName}'");
+				Assert.AreEqual(blob.IsFile, !blob.Name.EndsWith("/"), $"Wrong kind for '{blob.FullName}'");
+			}
+
+			BlobItemWrapper folder = blobs.Find(b => !b.IsFile);
+			Assert.IsNotNull(folder, "Expected a nested folder under 'folder1/'");
+			Assert.AreEqual("folder1/folder11/", folder.FullName, "A prefix must keep its trailing slash");
+		}
+
+		/// <summary>
+		/// A blob at the root of a container has no parent path. This is the case that used to
+		/// throw 'length must be a non-negative value' when the account was reached through a
+		/// host-style URL while the azurite flag was set.
+		/// </summary>
+		[TestMethod]
+		public async Task RootBlobHasNoPath()
+		{
+			StorageFactory factory = new StorageFactory();
+			List<BlobItemWrapper> blobs = await factory.Containers.ListBlobsAsync("with-many-folders", string.Empty);
+
+			BlobItemWrapper root = blobs.Find(b => b.IsFile);
+			Assert.IsNotNull(root, "Expected a file at the container root");
+			Assert.AreEqual(string.Empty, root.Path, "A root blob must have an empty path");
+			Assert.AreEqual("file-at-root", root.FullName);
+			Assert.AreEqual("file-at-root", root.Name);
 		}
 
 		[TestMethod]

--- a/tests/StorageLibTests/FileShareTests.cs
+++ b/tests/StorageLibTests/FileShareTests.cs
@@ -41,11 +41,11 @@ namespace StorageLibTests
 		public async Task GetShareFiles()
 		{
 			string fileShareName = "one";
-			List<FileShareItemWrapper> expected = new List<FileShareItemWrapper>
+			List<string> expected = new List<string>
 			{
-				new FileShareItemWrapper($"{MockUtils.FAKE_URL}/{fileShareName}/fromOne:1", true, MockUtils.NewRandomSize),
-				new FileShareItemWrapper($"{MockUtils.FAKE_URL}/{fileShareName}/fromOne:2", true, MockUtils.NewRandomSize),
-				new FileShareItemWrapper($"{MockUtils.FAKE_URL}/{fileShareName}/fromOne:3", true, MockUtils.NewRandomSize)
+				$"{MockUtils.FAKE_URL}/{fileShareName}/fromOne:1",
+				$"{MockUtils.FAKE_URL}/{fileShareName}/fromOne:2",
+				$"{MockUtils.FAKE_URL}/{fileShareName}/fromOne:3"
 			};
 
 			StorageFactory factory = new StorageFactory();
@@ -53,7 +53,28 @@ namespace StorageLibTests
 
 			Assert.HasCount(expected.Count, files, $"Different amount returned. {string.Join(",", files)}");
 			for (int i = 0; i < expected.Count; i++)
-				Assert.AreEqual(files[i].Url, expected[i].Url, $"Different objecte returned. Expected '{expected[i].Url}' got '{files[i].Url}'");
+				Assert.AreEqual(files[i].Url, expected[i], $"Different objecte returned. Expected '{expected[i]}' got '{files[i].Url}'");
+		}
+
+		/// <summary>
+		/// Same round-trip guarantee as for blobs: Path and Name must reproduce the name the
+		/// provider gave us. DownloadFile and DeleteFile pass Path as the directory, so a
+		/// wrong split silently reads from the wrong folder.
+		/// </summary>
+		[TestMethod]
+		public async Task FileNamesRoundTrip()
+		{
+			StorageFactory factory = new StorageFactory();
+			List<FileShareItemWrapper> files = await factory.Files.ListFilesAndDirsAsync("brothers", "seba/");
+
+			Assert.HasCount(3, files, $"Unexpected listing for 'seba/'. {string.Join(",", files)}");
+
+			foreach (FileShareItemWrapper file in files)
+			{
+				Assert.AreEqual("brothers", file.FileShare, $"Wrong share for '{file.FullName}'");
+				Assert.AreEqual(file.FullName, $"{file.Path}{file.Name}", $"Path+Name does not reproduce FullName for '{file.FullName}'");
+				Assert.AreEqual("seba/", file.Path, $"Wrong path for '{file.FullName}'");
+			}
 		}
 
 		[TestMethod]


### PR DESCRIPTION
## Direct browser-to-storage uploads

A blob now goes straight from the browser to storage through a short-lived (15 min) SAS URL, so the bytes never cross the Blazor circuit. Progress is reported back over the circuit at whole-percent granularity to keep chatter bounded.

If the direct `PUT` never reaches storage — CORS preflight refused, offline, DNS — the upload falls back to the old server-proxied path rather than failing. `XMLHttpRequest` is used instead of `fetch` because only xhr exposes upload progress events.

`MAX_SERVER_UPLOAD_MEGS` (default `10`) configures the cap on what that server-side fallback will buffer. Direct uploads are unaffected by it.

## Stop deriving item identity from URLs

`BlobItemWrapper` and `FileShareItemWrapper` took a URL and re-derived the container, path, and name by parsing it. That guessed wrong whenever the account name sat in the *path* rather than the host, so listing blobs on a real account while `AZURITE=true` was set threw:

```
length ('-3') must be a non-negative value. (Parameter 'length')
```

The flag only exposed the defect — reconstructing identity from a URL was the bug. Every provider already has the container and the relative key at the moment it builds a wrapper (`blobItem.Blob.Name`, `blobItem.Prefix`, `entry.Key`, `obj.Name`), and the pages that re-parsed a URL back into a wrapper already had the object in scope.

Both wrappers now take the container/share and the item's name as constructor arguments. `Url` is carried for display and equality only and is never parsed. `Common/StorageItemName.Split` does the name split, so **`Path + Name == FullName` always holds**. This also removes the `UrlDecode`/`IndexOf` fragility around names containing `%`, `+`, spaces, or `:`.

`FileShareItemWrapper` had the same defect with no flag at all (hardcoded host-style), so file-share paths were silently wrong under Azurite — worse than a crash, since `DownloadFile` passed `Path` as the directory and read from the wrong folder.

Two adjacent bugs on lines this already touched, fixed rather than smuggled past:
- `MoveUp` threw on a single-character file-share path.
- Every GCP blob URL pointed at a hardcoded test bucket.

## UX

- Errors are dismissible instead of vanishing after five seconds. The banner stays in the DOM and is hidden via `display:none`, because Semantic UI zeroes top margins with `:first-child` and adding/removing the element shifts page content.
- An extension-less blob no longer downloads as `<name>.txt`. The JS `Blob` is typed `application/octet-stream`, which has no canonical extension, so the browser stops appending one inferred from sniffed `text/plain`.

## Build and test tooling

- `compose` builds from `../src` instead of requiring a pre-built image; `dbuild` stamps a `BUILD` timestamp so an image reports which build it came from.
- Host port bindings pinned to `127.0.0.1` so a local run isn't served to the whole network.
- New `src/TestDockerfile` + `just dtest` run the unit tests in a container. Build context is the repo root because the test project references `../../src/StorageLibrary`; it strips the host's `obj/` and `bin/` after copying, since the repo has no `.dockerignore` and those assets files hold absolute host paths.

## Verification

Unit tests pass via `just dtest`. `ContainersTests` and `FileShareTests` run against the in-memory mocks (no credentials needed) and gained coverage for the invariant above, including `RootBlobHasNoPath` — the exact container-root shape that used to throw `-3`.

Paths worth exercising manually before merge, since the mocks can't cover them:
- Sign in with a real account connection string and list blobs at a container root (the original crash), then repeat with `AZURITE=true` exported — the flag must no longer affect listing at all.
- File shares under Azurite via `just compose`: enter a directory and download from it. Paths were wrong here before.
- A blob whose name contains `+`, `%`, or a space.
- A direct upload against a bucket *without* CORS configured, to confirm the fallback engages.

## Notes

- Version bumped 3.3.0 → 4.0.0.
- Eight dependency bumps were deliberately left out for Dependabot. Worth knowing: `.github/dependabot.yml` has nuget entries for `/src/web` and `/src/StorageLibrary` but **not** `/tests/StorageLibTests`, which is why the MSTest and Test.Sdk versions there have drifted furthest.
- Out of scope, filed for later: `AZURITE=true` still overrides explicit login credentials. With the wrappers fixed it no longer crashes anything, but it still pins an emulator service version and sets `SasProtocol.HttpsAndHttp` for a real account. The real fix is deriving it from the endpoint in use rather than an ambient env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)